### PR TITLE
Bug fix in borrowing a book from the library

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,7 +39,7 @@ app.use(function(req, res, next) {
   res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization");
   res.header("Access-Control-Allow-Methods", "OPTIONS, GET, POST, PUT");
   if(req.method === 'OPTIONS') {
-      res.send(200);
+      res.sendStatus(200);
       return;
   }
   next();

--- a/server/controllers/book-controller.js
+++ b/server/controllers/book-controller.js
@@ -35,4 +35,20 @@ deleteBook = function(req, res) {
   });
 }
 
-module.exports = {saveBook: saveBook, deleteBook: deleteBook};
+/**
+ * Find books from library by title. Uses a partial case-insensitive match by
+ * book title. Response will contain an array of books that match the criteria.
+ */
+findBook = function(req, res) {
+  let query = Book.where({ title : { $regex : req.query.title, $options : "i"} });
+  query.exec(function(err, books) {
+    if (err) {
+      console.log(err);
+      res.status(500).json({status : 'failure', message: 'Operation failed.'});
+    } else {
+      res.status(200).json({status: 'success', books: books})
+    }
+  });
+}
+
+module.exports = {saveBook: saveBook, deleteBook: deleteBook, findBook: findBook};

--- a/server/controllers/loan-controller.js
+++ b/server/controllers/loan-controller.js
@@ -27,7 +27,13 @@ borrowBook = function(req, res) {
             if (err) res.json({ status: 'failure', message: 'Borrowing the book failed.' });
             else {
               Book.findByIdAndUpdate(book_id, {current_loan: loan._id}, {new: true}, function(err, newBook) {
-                res.json({ status: 'success', book: newBook });
+                if (err) res.json({ status: 'failure', message: 'Borrowing the book failed!' });
+                else {
+                  //Populate the book object with the loan object 
+                  Book.populate(newBook, {path: 'current_loan'}, function(err, book) {
+                    res.json({ status: 'success', book: newBook });
+                  });
+                }
               });
             }
           });

--- a/server/routes/books-router.js
+++ b/server/routes/books-router.js
@@ -21,6 +21,15 @@ router.route('/')
     });
   });
 
+router.route('/find')
+
+  .get(function(req, res) {
+    if(req.isAuthenticated()) {
+      bookController.findBook(req, res);
+    }
+    else res.status(401).json({ error: 'Not logged in.' });
+  });
+
 router.route('/:book_id')
 
   //Get a single book by _id


### PR DESCRIPTION
Fix a method deprecated error in server.js:
* response.send(200) should be replaced with response.sendStatus(200)

Bug fix in borrowing a book:
* Previously when pressing the "Borrow" button for a book item, the spinning wheel kept on spinning and didn't show the updated book status. After reloading the page the new status is shown.
* There was an error thrown on the client side when borrowing a book since the client expects the book object to contain the loan object, but the API was sending a reference to the loan instead. 
* We need to populate the book object with the related loan object instead of an id reference.